### PR TITLE
Transient shopping item

### DIFF
--- a/src/main/java/kernbeisser/DBEntities/ShoppingItem.java
+++ b/src/main/java/kernbeisser/DBEntities/ShoppingItem.java
@@ -408,7 +408,7 @@ public class ShoppingItem implements Serializable {
 
   @Key(PermissionKey.SHOPPING_ITEM_ITEM_RETAIL_PRICE_READ)
   public double calculatePreciseRetailPrice(double netPrice) throws NullPointerException {
-    return Articles.calculateRetailPrice(netPrice, vat, surcharge, discount, isContainerDiscount());
+    return Articles.calculateRetailPrice(netPrice, vat, surcharge, discount, false);
   }
 
   @Key(PermissionKey.SHOPPING_ITEM_ITEM_RETAIL_PRICE_READ)

--- a/src/main/java/kernbeisser/Enums/MetricUnits.java
+++ b/src/main/java/kernbeisser/Enums/MetricUnits.java
@@ -26,7 +26,7 @@ public enum MetricUnits implements Named {
       return 1;
     }
   },
-  NONE("Undefinierte Einheit", "?") {
+  NONE("Undefinierte Einheit", "-") {
     @Override
     public double getBaseFactor() {
       return 1;

--- a/src/main/java/kernbeisser/Windows/EditArticles/EditItemsController.java
+++ b/src/main/java/kernbeisser/Windows/EditArticles/EditItemsController.java
@@ -75,7 +75,7 @@ public class EditItemsController extends Controller<EditItemsView, EditItemsMode
                 .withSorter(Column.NUMBER_SORTER),
             new CustomizableColumn<Article>(
                     "Verkaufspreis",
-                    e -> String.format("%.2f€", Articles.calculateArticleRetailPrice(e)))
+                    e -> String.format("%.2f€", Articles.calculateArticleRetailPrice(e, 0, false)))
                 .withHorizontalAlignment(RIGHT)
                 .withSorter(Column.NUMBER_SORTER),
             Columns.create("Einzelpfand", e -> String.format("%.2f€", e.getSingleDeposit()), RIGHT),

--- a/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskModel.java
+++ b/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskModel.java
@@ -6,6 +6,7 @@ import kernbeisser.DBEntities.Articles;
 import kernbeisser.DBEntities.SaleSession;
 import kernbeisser.DBEntities.ShoppingItem;
 import kernbeisser.DBEntities.Supplier;
+import kernbeisser.EntityWrapper.ObjectState;
 import kernbeisser.Exeptions.NotEnoughCreditException;
 import kernbeisser.Windows.MVC.IModel;
 import lombok.Data;
@@ -26,22 +27,28 @@ public class ShoppingMaskModel implements IModel<ShoppingMaskUIController> {
     this.value = saleSession.getCustomer().getUserGroup().getValue();
   }
 
-  ShoppingItem getByKbNumber(int kbNumber, int discount, boolean preordered) {
+  Article getArticleByKbNumber(int kbNumber) {
+    return Articles.getByKbNumber(kbNumber, true).map(ObjectState::getValue).orElse(null);
+  }
+
+  ShoppingItem getItemByKbNumber(int kbNumber, int discount, boolean preordered) {
     return Articles.getByKbNumber(kbNumber, true)
         .map(e -> new ShoppingItem(e, discount, preordered))
         .orElse(null);
   }
 
-  ShoppingItem getBySupplierItemNumber(
+  Article getArticleBySupplierItemNumber(Supplier supplier, int suppliersNumber) {
+    return Articles.getBySuppliersItemNumber(supplier, suppliersNumber).orElse(null);
+  }
+
+  ShoppingItem getItemBySupplierItemNumber(
       Supplier supplier, int suppliersNumber, int discount, boolean preordered) {
     return Articles.getBySuppliersItemNumber(supplier, suppliersNumber)
         .map(e -> new ShoppingItem(e, discount, preordered))
         .orElse(null);
   }
 
-  ShoppingItem getByBarcode(long barcode, int discount, boolean preordered)
-      throws NoResultException {
-    return new ShoppingItem(
-        Articles.getByBarcode(barcode).orElseThrow(NoResultException::new), discount, preordered);
+  Article getByBarcode(long barcode) throws NoResultException {
+    return (Articles.getByBarcode(barcode).orElseThrow(NoResultException::new));
   }
 }

--- a/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskUIController.java
+++ b/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskUIController.java
@@ -186,9 +186,16 @@ public class ShoppingMaskUIController extends Controller<ShoppingMaskUIView, Sho
     }
   }
 
-  public Double recalculatePrice(Article article, double discount, boolean preordered)
+  public Double recalculatePrice(
+      Article article, double discount, boolean preordered, boolean overwriteNetPrice)
       throws NullPointerException {
-    return Articles.calculateArticleRetailPrice(article, discount, preordered);
+    if (overwriteNetPrice) {
+      article.setNetPrice(view.getNetPrice());
+    }
+    return Articles.calculateArticleRetailPrice(article, discount, preordered)
+        * (preordered && !article.isWeighable() && !overwriteNetPrice
+            ? article.getContainerSize()
+            : 1.0);
   }
 
   public Article extractArticleFromUI() throws NullPointerException {

--- a/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskUIView.form
+++ b/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskUIView.form
@@ -151,7 +151,7 @@
                       <text value="Verkaufspreis:"/>
                     </properties>
                   </component>
-                  <component id="bc220" class="kernbeisser.CustomComponents.TextFields.DoubleParseField" binding="price">
+                  <component id="bc220" class="kernbeisser.CustomComponents.TextFields.DoubleParseField" binding="retailPrice">
                     <constraints>
                       <grid row="7" column="3" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
                       <gridbag top="0" left="5" bottom="0" right="5" weightx="0.3" weighty="0.0"/>
@@ -170,7 +170,7 @@
                       <text value="Menge:"/>
                     </properties>
                   </component>
-                  <component id="f8f5d" class="kernbeisser.CustomComponents.TextFields.DoubleParseField" binding="amount">
+                  <component id="f8f5d" class="kernbeisser.CustomComponents.TextFields.DoubleParseField" binding="itemMultiplier">
                     <constraints>
                       <grid row="8" column="3" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
                       <gridbag top="0" left="5" bottom="0" right="5" weightx="0.0" weighty="0.0"/>
@@ -208,7 +208,7 @@
                       <font size="16" style="0"/>
                     </properties>
                   </component>
-                  <component id="be8aa" class="javax.swing.JLabel" binding="priceUnit">
+                  <component id="be8aa" class="javax.swing.JLabel" binding="retailPriceUnit">
                     <constraints>
                       <grid row="7" column="5" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                       <gridbag top="0" left="0" bottom="0" right="5" weightx="0.0" weighty="0.0"/>
@@ -219,7 +219,7 @@
                       <text value="€/kg"/>
                     </properties>
                   </component>
-                  <component id="6c207" class="javax.swing.JLabel" binding="amountUnit">
+                  <component id="6c207" class="javax.swing.JLabel" binding="itemMultiplierUnit">
                     <constraints>
                       <grid row="8" column="5" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                       <gridbag top="0" left="0" bottom="0" right="5" weightx="0.0" weighty="0.0"/>

--- a/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskUIView.java
+++ b/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskUIView.java
@@ -98,7 +98,6 @@ public class ShoppingMaskUIView implements IView<ShoppingMaskUIController> {
   static Vector<Component> traversalOrder = new Vector<>(1);
   static FocusTraversal traversalPolicy;
   @Getter private boolean isPreordered = false;
-  private ShoppingItem currentItem;
 
   EnumSet<ArticleType> articleTypesWithSettablePrice;
   EnumSet<ArticleType> depositArticleTypes;
@@ -388,11 +387,6 @@ public class ShoppingMaskUIView implements IView<ShoppingMaskUIController> {
     }
   }
 
-  // TODO Remove
-  private boolean isCustomArticle(ShoppingItem item) {
-    return item.getKbNumber() == ArticleConstants.CUSTOM_PRODUCT.getUniqueIdentifier();
-  }
-
   private String intToStringNot0(int value) {
     if (value == 0) return "";
     return Integer.toString(value);
@@ -449,19 +443,6 @@ public class ShoppingMaskUIView implements IView<ShoppingMaskUIController> {
     updateAllControls(currentArticleType);
   }
 
-  void loadItemStats(ShoppingItem shoppingItem) {
-    currentItem = shoppingItem;
-    isWeighable = shoppingItem.isWeighAble();
-    if (isCustomArticle(shoppingItem)) return;
-    String itemPriceUnits = shoppingItem.getPriceUnits().getShortName();
-    containerSize.setText(
-        new DecimalFormat("##.###")
-            .format(shoppingItem.getContainerSize() * (isWeighable ? 1000 : 1)));
-    containerUnit.setText(shoppingItem.getContainerUnits().getShortName());
-    deposit.setText(String.format("%.2f", shoppingItem.getSingleDeposit()));
-    updateAllControls(currentArticleType);
-  }
-
   private void recalculatePrice() {
     // Refactor => articlebased
     if (getKBArticleNumber() > 0 || isPreordered) {
@@ -487,7 +468,6 @@ public class ShoppingMaskUIView implements IView<ShoppingMaskUIController> {
     articleName.setText("Keinen Artikel gefunden!");
     itemMultiplierUnit.setText("");
     containerUnit.setText("");
-    currentItem = null;
   }
 
   void messageNoArticleFound() {

--- a/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskUIView.java
+++ b/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskUIView.java
@@ -342,19 +342,15 @@ public class ShoppingMaskUIView implements IView<ShoppingMaskUIController> {
         priceVariablePercentage.isEnabled() && priceVariablePercentage.isSelected());
 
     if (type == ArticleType.PRODUCE || type == ArticleType.BAKED_GOODS) {
-      if (type == ArticleType.PRODUCE) {
-        loadItemStats(Objects.requireNonNull(ShoppingItem.createProduce(0.0, isPreordered)));
-        this.articleName.setText("Obst & Gemüse");
-      } else {
-        loadItemStats(Objects.requireNonNull(ShoppingItem.createBakeryProduct(0.0, isPreordered)));
-        this.articleName.setText("Backwaren");
-      }
+      RawPrice rawPrice = type == ArticleType.PRODUCE ? RawPrice.PRODUCE : RawPrice.BAKERY;
+      loadArticleStats(Articles.getOrCreateRawPriceArticle(rawPrice));
+      this.articleName.setText(rawPrice.getName());
       if (isPreordered) {
         netPrice.requestFocusInWindow();
         netPrice.selectAll();
       } else {
-        price.requestFocusInWindow();
-        price.selectAll();
+        retailPrice.requestFocusInWindow();
+        retailPrice.selectAll();
       }
     } else if (type == ArticleType.DEPOSIT) {
       this.articleName.setText("Pfand-Behälter");

--- a/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskUIView.java
+++ b/src/main/java/kernbeisser/Windows/ShoppingMask/ShoppingMaskUIView.java
@@ -417,7 +417,8 @@ public class ShoppingMaskUIView implements IView<ShoppingMaskUIController> {
       double unitNetPrice =
           article.getNetPrice() * (isPreordered && !isWeighable ? article.getContainerSize() : 1.0);
       netPrice.setText(AccessCheckingField.UNSIGNED_CURRENCY_FORMER.toString(unitNetPrice));
-      retailPrice.setText(formattedPrice(controller.recalculatePrice(article, getDiscount(), isPreordered, false)));
+      retailPrice.setText(
+          formattedPrice(controller.recalculatePrice(article, getDiscount(), isPreordered, false)));
     } catch (NullPointerException e) {
       netPrice.setText("");
       retailPrice.setText("");
@@ -427,7 +428,8 @@ public class ShoppingMaskUIView implements IView<ShoppingMaskUIController> {
       String unit = MetricUnits.CONTAINER.getShortName();
       priceUnit += "/" + unit;
       itemMultiplierUnit.setText(unit);
-    } else if (getArticleType() == ArticleType.ARTICLE_NUMBER || getArticleType() == ArticleType.CUSTOM_PRODUCT){
+    } else if (getArticleType() == ArticleType.ARTICLE_NUMBER
+        || getArticleType() == ArticleType.CUSTOM_PRODUCT) {
       priceUnit += "/" + Articles.getPriceUnit(article).getShortName();
       itemMultiplierUnit.setText(Articles.getMultiplierUnit(article).getShortName());
     } else {
@@ -451,8 +453,7 @@ public class ShoppingMaskUIView implements IView<ShoppingMaskUIController> {
       Article article = controller.extractArticleFromUI();
       try {
         double retailPrice =
-            controller.recalculatePrice(
-                article, getDiscount(), isPreordered(), overWriteNetPrice);
+            controller.recalculatePrice(article, getDiscount(), isPreordered(), overWriteNetPrice);
         if (retailPrice <= 0) {
           throw new NullPointerException();
         }
@@ -883,7 +884,17 @@ public class ShoppingMaskUIView implements IView<ShoppingMaskUIController> {
           variablePercentage.requestFocusInWindow();
           disablePreordered();
         });
-    variablePercentage.addActionListener(e -> addToCart());
+    variablePercentage.addKeyListener(
+        new KeyAdapter() {
+          @Override
+          public void keyReleased(KeyEvent e) {
+            if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+              addToCart();
+            } else {
+              recalculateRetailPrice(false);
+            }
+          }
+        });
 
     editUser.setIcon(IconFontSwing.buildIcon(FontAwesome.INFO, 20, new Color(49, 114, 128)));
     editUser.addActionListener(e -> controller.openUserInfo());
@@ -925,6 +936,8 @@ public class ShoppingMaskUIView implements IView<ShoppingMaskUIController> {
       isPreordered = false;
       articleTypeInitialize(currentArticleType);
       articleNameOrVatChange();
+    } else {
+      recalculateRetailPrice(false);
     }
   }
 


### PR DESCRIPTION
Comprehensive refactoring of ShoppingMask. Usage of ShoppingItem for populating controls lead to problems with ObjectState<Article>, because that requires persisted Article. All Shopping Mask UI relevant logic of ShoppingItem is therefore moved to Articles and Shopping Mask is now populated by Article.
This pull request may contain interim commits, that lead to states that do not compile!