### PR TITLE
Allow 2 shopping instances

### DIFF
--- a/app/src/main/java/kernbeisser/Windows/CashierShoppingMask/CashierShoppingMaskController.java
+++ b/app/src/main/java/kernbeisser/Windows/CashierShoppingMask/CashierShoppingMaskController.java
@@ -73,30 +73,26 @@ public class CashierShoppingMaskController
   }
 
   public void openMaskWindow() {
-    if (model.isOpenLock()) {
-      getView().messageShoppingMaskAlreadyOpened();
-      return;
-    }
-    boolean allowMultiple =
-        UserSetting.ALLOW_MULTIPLE_SHOPPING_MASK_INSTANCES.getBooleanValue(
-            LogInModel.getLoggedIn());
-    SaleSession saleSession = new SaleSession(SaleSessionType.ASSISTED);
-    saleSession.setCustomer(searchBoxController.getSelectedObject().get());
-    saleSession.setSeller(LogInModel.getLoggedIn());
-    if (!getView().getSecondSeller().toString().equals("Keiner")) {
-      try {
-        saleSession.setSecondSeller(getView().getSecondSeller());
-      } catch (NoResultException e) {
+    try {
+      if (model.isOpenLock()) {
+        getView().messageShoppingMaskAlreadyOpened();
         return;
       }
-    }
-    try {
+      boolean allowMultiple =
+          UserSetting.ALLOW_MULTIPLE_SHOPPING_MASK_INSTANCES.getBooleanValue(
+              LogInModel.getLoggedIn());
+      SaleSession saleSession =
+          model.createSaleSession(
+              SaleSessionType.ASSISTED,
+              searchBoxController.getSelectedObject().get(),
+              getView().getSecondSeller());
       if (!allowMultiple) {
         new ShoppingMaskController(saleSession).withCloseEvent(() -> setAllowOpen(true)).openTab();
         setAllowOpen(false);
       } else new ShoppingMaskController(saleSession).openTab();
     } catch (NotEnoughCreditException e) {
       getView().notEnoughCredit();
+    } catch (NoResultException ignored) {
     }
   }
 

--- a/app/src/main/java/kernbeisser/Windows/CashierShoppingMask/CashierShoppingMaskModel.java
+++ b/app/src/main/java/kernbeisser/Windows/CashierShoppingMask/CashierShoppingMaskModel.java
@@ -3,10 +3,14 @@ package kernbeisser.Windows.CashierShoppingMask;
 import java.util.List;
 import kernbeisser.Config.Config;
 import kernbeisser.DBEntities.Repositories.TransactionRepository;
+import kernbeisser.DBEntities.SaleSession;
 import kernbeisser.DBEntities.Transaction;
+import kernbeisser.DBEntities.User;
+import kernbeisser.Enums.SaleSessionType;
 import kernbeisser.Exeptions.NoTransactionsFoundException;
 import kernbeisser.Exeptions.handler.UnexpectedExceptionHandler;
 import kernbeisser.Reports.AccountingReport;
+import kernbeisser.Windows.LogIn.LogInModel;
 import kernbeisser.Windows.MVC.IModel;
 import lombok.Data;
 
@@ -49,5 +53,16 @@ public class CashierShoppingMaskModel implements IModel<CashierShoppingMaskContr
     } catch (Exception e) {
       return unreportedTransactions.size();
     }
+  }
+
+  public SaleSession createSaleSession(
+      SaleSessionType saleSessionType, User customer, User secondSeller) {
+    SaleSession saleSession = new SaleSession(saleSessionType);
+    saleSession.setCustomer(customer);
+    saleSession.setSeller(LogInModel.getLoggedIn());
+    if (!secondSeller.toString().equals("Keiner")) {
+      saleSession.setSecondSeller(secondSeller);
+    }
+    return saleSession;
   }
 }

--- a/app/src/main/java/kernbeisser/Windows/Pay/PayModel.java
+++ b/app/src/main/java/kernbeisser/Windows/Pay/PayModel.java
@@ -3,6 +3,7 @@ package kernbeisser.Windows.Pay;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.PersistenceException;
+import jakarta.persistence.Tuple;
 import java.util.List;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBConnection.QueryBuilder;
@@ -81,24 +82,43 @@ public class PayModel implements IModel<PayController> {
   long pay() throws PersistenceException, InvalidTransactionException {
     // Build connection to DB and start payment transaction
     @Cleanup EntityManager em = DBConnection.getEntityManager();
+    em.clear();
     EntityTransaction et = em.getTransaction();
     try {
-      long lastBonNo =
-          QueryBuilder.select(Purchase_.bonNo)
+      Object[] lastPurchaseValues =
+          QueryBuilder.select(Purchase_.id, Purchase_.bonNo)
               .orderBy(Purchase_.bonNo.desc())
               .limit(1)
               .getSingleResultOptional()
-              .orElse(0L);
-      et.begin();
-      exchangeMoney(em);
-      Purchase purchase = new Purchase();
-      purchase.setSession(saleSession);
-      purchase.setBonNo(lastBonNo + 1);
-      em.persist(saleSession);
-      em.persist(purchase);
-      persistShoppingCartAndRectifyIndexes(em, purchase);
-      et.commit();
-      return purchase.getBonNo();
+              .map(Tuple::toArray)
+              .orElse(new Long[] {0L, 0L});
+      long lastPurchaseId = (long) lastPurchaseValues[0];
+      long bonNo = (long) lastPurchaseValues[1] + 1;
+      boolean inconsistent = true;
+      // JPA creates inconsistent purchase id if another purchase was persisted with another
+      // instance :(
+      do {
+        et.begin();
+        exchangeMoney(em);
+        Purchase purchase = new Purchase();
+        purchase.setSession(saleSession);
+        purchase.setBonNo(bonNo);
+        em.persist(saleSession);
+        em.persist(purchase);
+
+        // check, whether the new id is consistent with the database
+        if (purchase.getId() > lastPurchaseId) {
+          persistShoppingCartAndRectifyIndexes(em, purchase);
+          et.commit();
+          inconsistent = false;
+        } else {
+          et.rollback();
+          em.clear();
+          saleSession.setId(0);
+        }
+      } while (inconsistent);
+      return bonNo;
+
     } finally {
       // rolls back any made changes when the payment was interrupted
       // only happens if the code doesn't reach the commit statement


### PR DESCRIPTION
When opening 2 instances of the software, and perform purchases in both of them, an exception during pay could appear with the result, that the shopping basket was lost. This arrises from weird JPA behavior in id calculation. An id check on the vulnerable entity avoids the exception. After entity transaction rollback and entity manager clear the id is calculated properly. very weird...    